### PR TITLE
Fix replacing "postalCode" query param with the more correct "zip" param.

### DIFF
--- a/lib/Scrape/USPS/ZipLookup.pm
+++ b/lib/Scrape/USPS/ZipLookup.pm
@@ -140,8 +140,8 @@ sub std_inner
     city        => $addr->city // '',
     state       => $addr->state // '',
     urbanCode   => '',
-    postalCode  => $addr->zip_code // '',
-    zip         => ''
+    postalCode  => '',
+    zip         => $addr->zip_code // ''
   ];
     
   $response = $ua->request($temp);


### PR DESCRIPTION
"postalCode" did not work as intended.  You can now pass an address and
a zip code, without city and state, and should get a valid response if
your address and zip combination is valid.

Commit lacks unit tests!
